### PR TITLE
Improved: css for first ion-item of list-item to make its width 100% (fulfillment-564)

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -72,6 +72,10 @@ ion-button > ion-spinner {
   justify-self: start
 }
 
+.list-item > ion-item:first-child {
+  width: 100%;
+}
+
 /* Add a border to the top of the row item. Using border top so that the last item doesn't have a border below it */
 hr {
   border-top: 1px solid var(--ion-color-medium);


### PR DESCRIPTION
## Related Issue
https://github.com/hotwax/fulfillment/issues/564

## Description
Making the ion-item width 100% if it's first child of the list-item